### PR TITLE
Qs/Flake: addition of a simple flake package

### DIFF
--- a/configs/quickshell/flake.nix
+++ b/configs/quickshell/flake.nix
@@ -5,28 +5,27 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs =
-    { self, nixpkgs }:
-    let
-      system = "x86_64-linux";
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    system = "x86_64-linux";
 
-      pkgs = import nixpkgs {
-        inherit system;
-        config = { };
-      };
-    in
-    {
-      devShells.${system}.default = pkgs.mkShell {
-        nativeBuildInputs = with pkgs; [
-        ];
-        buildInputs = with pkgs; [
-          kdePackages.qtdeclarative
-          kdePackages.qt5compat
-        ];
-        shellHook = ''
-          export QML_IMPORT_PATH=$PWD/src
-        '';
-      };
+    pkgs = import nixpkgs {
+      inherit system;
+      config = {};
     };
-
+  in {
+    packages.${system}.default = pkgs.callPackage ./package.nix {};
+    devShells.${system}.default = pkgs.mkShell {
+      nativeBuildInputs = with pkgs; [];
+      buildInputs = with pkgs; [
+        kdePackages.qtdeclarative
+        kdePackages.qt5compat
+      ];
+      shellHook = ''
+        export QML_IMPORT_PATH=$PWD/src
+      '';
+    };
+  };
 }

--- a/configs/quickshell/package.nix
+++ b/configs/quickshell/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  symlinkJoin,
+  makeWrapper,
+  quickshell,
+  kdePackages,
+  configPath ? ./.,
+}: let
+  qmlPath = lib.makeSearchPath "lib/qt-6/qml" [
+    kdePackages.qtbase
+    kdePackages.qtdeclarative
+    kdePackages.qt5compat
+  ];
+in
+  symlinkJoin {
+    pname = "retroism";
+    inherit (quickshell) version;
+
+    paths = [quickshell];
+    nativeBuildInputs = [makeWrapper];
+
+    postBuild = ''
+      makeWrapper $out/bin/quickshell $out/bin/retroism \
+        --set QML2_IMPORT_PATH "${qmlPath}" \
+        --add-flags '-p ${configPath}'
+    '';
+
+    meta.mainProgram = "retroism";
+  }


### PR DESCRIPTION
- added a package.nix that wraps quickshell with the qs config into an executable called retroism
- formatted the flake and exported the package as packages.default