### PR TITLE
Fixed a Syntax error in the Kitty configs.

### DIFF
--- a/configs/kitty/cherry_theme.conf
+++ b/configs/kitty/cherry_theme.conf
@@ -14,7 +14,7 @@ font_size 11
 
 # Just a keybind to change font size to your liking, it's CTRL + scroll wheel up or down.
 map ctrl+shift+plus change_font_size all +1.0
-map ctrl+shift+minus change font size all -1.0
+map ctrl+shift+minus change_font_size all -1.0
 
 # Background opacity, set to 0 if you want blur/transparency.
 # Blur works with hyprland, or sway-fx as a drop-in replacement for sway.

--- a/configs/kitty/default_theme.conf
+++ b/configs/kitty/default_theme.conf
@@ -14,7 +14,7 @@ font_size 11
 
 # Just a keybind to change font size to your liking, it's CTRL + scroll wheel up or down.
 map ctrl+shift+plus change_font_size all +1.0
-map ctrl+shift+minus change font size all -1.0
+map ctrl+shift+minus change_font_size all -1.0
 
 # Background opacity, set to 0 if you want blur/transparency.
 # Blur works with hyprland, or sway-fx as a drop-in replacement for sway.

--- a/configs/kitty/gleep_theme.conf
+++ b/configs/kitty/gleep_theme.conf
@@ -14,7 +14,7 @@ font_size 11
 
 # Just a keybind to change font size to your liking, it's CTRL + scroll wheel up or down.
 map ctrl+shift+plus change_font_size all +1.0
-map ctrl+shift+minus change font size all -1.0
+map ctrl+shift+minus change_font_size all -1.0
 
 # Background opacity, set to 0 if you want blur/transparency.
 # Blur works with hyprland, or sway-fx as a drop-in replacement for sway.

--- a/configs/kitty/indigo_theme.conf
+++ b/configs/kitty/indigo_theme.conf
@@ -14,7 +14,7 @@ font_size 11
 
 # Just a keybind to change font size to your liking, it's CTRL + scroll wheel up or down.
 map ctrl+shift+plus change_font_size all +1.0
-map ctrl+shift+minus change font size all -1.0
+map ctrl+shift+minus change_font_size all -1.0
 
 # Background opacity, set to 0 if you want blur/transparency.
 # Blur works with hyprland, or sway-fx as a drop-in replacement for sway.

--- a/configs/kitty/yorha_theme.conf
+++ b/configs/kitty/yorha_theme.conf
@@ -14,7 +14,7 @@ font_size 11
 
 # Just a keybind to change font size to your liking, it's CTRL + scroll wheel up or down.
 map ctrl+shift+plus change_font_size all +1.0
-map ctrl+shift+minus change font size all -1.0
+map ctrl+shift+minus change_font_size all -1.0
 
 # Background opacity, set to 0 if you want blur/transparency.
 # Blur works with hyprland, or sway-fx as a drop-in replacement for sway.


### PR DESCRIPTION
There was a small Syntax error in the Kitty configs (cherry_theme.conf, default_theme.conf, gleep_theme.conf, indigo_theme.conf and yorha_theme.conf).

It currently looks like this:
```conf
map ctrl+shift+minus change font size all -1.0
```

I changed it to this:

```conf
map ctrl+shift+minus change_font_size all -1.0
```