### PR TITLE
Changes in Hyprland syntaxis

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -141,10 +141,6 @@ misc {
     force_default_wallpaper = 0
     disable_hyprland_logo = true
 }
-# No need for gestures unless you have a touch display.
-gestures {
-    workspace_swipe = false
-}
 
 
 #                                    !!KEYBINDS!!                                   #
@@ -220,31 +216,31 @@ bindel = ,XF86MonBrightnessDown, exec, brightnessctl s 10%-
 # you see fit.
 
 # adding more here as needed.
-windowrulev2 = minsize 250 250, class:^(Unity)$, title:^(Project Settings)$
-windowrulev2 = minsize 250 250, class:^(Unity)$, title:^(Preferences)$
-windowrulev2 = minsize 250 250, class:^(Unity)$, title:^(UnityEditor.AddComponent.AddComponentWindow)$
-windowrulev2 = minsize 250 250, class:^(Unity)$, title:^(Package Manager)$
-windowrulev2 = minsize 250 250, class:^(Unity)$, title:^(UI Toolkit Debugger)$
-windowrulev2 = minsize 250 500, class:^(Unity)$, title:^(Font Asset Creator)$
-windowrulev2 = minsize 500 250, class:^(Unity)$, title:^(Background Tasks)$
+windowrule = min_size 250 250, match:class ^(Unity)$, match:title ^(Project Settings)$
+windowrule = min_size 250 250, match:class ^(Unity)$, match:title ^(Preferences)$
+windowrule = min_size 250 250, match:class ^(Unity)$, match:title ^(UnityEditor.AddComponent.AddComponentWindow)$
+windowrule = min_size 250 250, match:class ^(Unity)$, match:title ^(Package Manager)$
+windowrule = min_size 250 250, match:class ^(Unity)$, match:title ^(UI Toolkit Debugger)$
+windowrule = min_size 250 500, match:class ^(Unity)$, match:title ^(Font Asset Creator)$
+windowrule = min_size 500 250, match:class ^(Unity)$, match:title ^(Background Tasks)$
 
 
-windowrulev2 = minsize 150 300, initialTitle:(UnityEditor.PopupWindow)
-windowrulev2 = minsize 230 200, initialTitle:(UnityEditor.AddComponent.AddComponentWindow)
-windowrulev2 = minsize 500 500, initialTitle:(UnityEngine.InputSystem.Editor.AdvancedDropdownWindow)
-windowrulev2 = minsize 230 500, initialTitle:(UnityEditor.AnnotationWindow)
-windowrulev2 = minsize 300 200, initialTitle:(UnityEditor.IMGUI.Controls.AdvancedDropdownWindow)
-windowrulev2 = move cursor, class:^(Unity)$, title:^(UnityEditor.AddComponent.AddComponentWindow)$
-windowrulev2 = move cursor, class:^(Unity)$, title:^(UnityEditor.IMGUI.Controls.AdvancedDropdownWindow)$
-windowrulev2 = move cursor, class:^(Unity)$, title:^(UnityEngine.InputSystem.Editor.AdvancedDropdownWindow)$
-windowrulev2 = move cursor, class:^(Unity)$, title:^(UnityEditor.PopupWindow)$
-windowrulev2 = move cursor, class:^(Unity)$, title:^(Preferences)$
+windowrule = min_size 150 300, match:initial_title (UnityEditor.PopupWindow)
+windowrule = min_size 230 200, match:initial_title (UnityEditor.AddComponent.AddComponentWindow)
+windowrule = min_size 500 500, match:initial_title (UnityEngine.InputSystem.Editor.AdvancedDropdownWindow)
+windowrule = min_size 230 500, match:initial_title (UnityEditor.AnnotationWindow)
+windowrule = min_size 300 200, match:initial_title (UnityEditor.IMGUI.Controls.AdvancedDropdownWindow)
+windowrule = move cursor, match:class ^(Unity)$, match:title ^(UnityEditor.AddComponent.AddComponentWindow)$
+windowrule = move cursor, match:class ^(Unity)$, match:title ^(UnityEditor.IMGUI.Controls.AdvancedDropdownWindow)$
+windowrule = move cursor, match:class ^(Unity)$, match:title ^(UnityEngine.InputSystem.Editor.AdvancedDropdownWindow)$
+windowrule = move cursor, match:class ^(Unity)$, match:title ^(UnityEditor.PopupWindow)$
+windowrule = move cursor, match:class ^(Unity)$, match:title ^(Preferences)$
 
-# windowrulev2 = move cursor, class:^(Unity)$
+# windowrule = move cursor, match:class ^(Unity)$
 
 # Color Picker for unity
-windowrulev2 = move cursor, class:^(Unity)$, title:^(Color)$
-windowrulev2 = move cursor, class:^(Unity)$, title:^(HDR Color)$
+windowrule = move cursor, match:class ^(Unity)$, match:title ^(Color)$
+windowrule = move cursor, match:class ^(Unity)$, match:title ^(HDR Color)$
 
 # Fix dragging issues with XWayland
-windowrulev2 = nofocus,class:^$,title:^$,xwayland:1,floating:1,fullscreen:0,pinned:0
+windowrule = match:focus 0, match:class ^$, match:title ^$, match:xwayland 1, match:float 1, match:fullscreen 0, match:pin 0


### PR DESCRIPTION
Since Hyprland 0.53 the syntax of window rules has changed:

- https://hypr.land/news/update53/
- https://wiki.hypr.land/Configuring/Window-Rules/

Also, the gestures block produces error from version 0.51 as they also changed the syntaxis.